### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/eCommApp/src/components/AdminPage.tsx
+++ b/eCommApp/src/components/AdminPage.tsx
@@ -18,7 +18,14 @@ const AdminPage = () => {
                         {/* Display error message above the input */}
                         {errorMessage && (
                             <div style={{ color: 'red', marginBottom: '0.5rem' }}>
-                                <span dangerouslySetInnerHTML={{ __html: errorMessage }} />
+                                <span>
+                                    {errorMessage.split('\n').map((line, index) => (
+                                        <span key={index}>
+                                            {line}
+                                            {index < errorMessage.split('\n').length - 1 && <br />}
+                                        </span>
+                                    ))}
+                                </span>
                             </div>
                         )}
                         <label htmlFor="salePercent">Set Sale Percent (% off for all items): </label>


### PR DESCRIPTION
Potential fix for [https://github.com/linnea-oxenwaldt/hol-copilot-lab/security/code-scanning/2](https://github.com/linnea-oxenwaldt/hol-copilot-lab/security/code-scanning/2)

In general, the way to fix this is to stop interpreting user-controlled strings as HTML. Instead of using `dangerouslySetInnerHTML`, render the error message as normal React text content, letting React handle escaping. If you need formatting (e.g., line breaks), you can either keep them as `\n` and style via CSS/white-space or split on `\n` and render them as separate `<span>`/`<p>` elements; but in any case, avoid feeding untrusted strings into HTML-parsing sinks.

For this specific code, the simplest and safest fix without changing functionality is:

- Replace the `<span dangerouslySetInnerHTML={{ __html: errorMessage }} />` with a normal text-rendering approach.
- Because the error message string already uses `\n` to separate lines, we can preserve the intended layout by splitting on `\n` and inserting `<br />` between lines, but still not interpreting any part of the string as HTML. That way, even if `inputValue` includes `<script>` or similar, it will be escaped by React and shown as literal text.

Concretely, in `eCommApp/src/components/AdminPage.tsx` around line 21:

- Change the `span` to render `errorMessage.split('\n')` as text nodes separated by `<br />`.
- No new imports are needed; we use only built-in JS string methods and React’s normal JSX text rendering.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
